### PR TITLE
libsodium: update to 1.0.20

### DIFF
--- a/rpm/libsodium.spec
+++ b/rpm/libsodium.spec
@@ -38,22 +38,16 @@ DO_NOT_UPDATE_CONFIG_SCRIPTS=1 ./autogen.sh
 make check
 
 %install
-rm -rf %{buildroot}
 %make_install
 
 %post -n libsodium -p /sbin/ldconfig
 
 %postun -n libsodium -p /sbin/ldconfig
 
-%clean
-rm -rf %{buildroot}
-
 %files
-%defattr(-,root,root,-)
 %{_libdir}/libsodium.so*
 
 %files devel
-%defattr(-,root,root,-)
 %{_includedir}/sodium.h
 %{_includedir}/sodium/*.h
 %{_libdir}/pkgconfig/libsodium.pc

--- a/rpm/libsodium.spec
+++ b/rpm/libsodium.spec
@@ -1,5 +1,5 @@
 Name:       libsodium
-Version:    1.0.18
+Version:    1.0.20
 Release:    1
 Summary:    A modern, portable, easy to use crypto library.
 Group:      Applications/Utilities

--- a/rpm/libsodium.spec
+++ b/rpm/libsodium.spec
@@ -23,6 +23,7 @@ Requires:   %{name} = %{version}-%{release}
 Sodium is a new, easy-to-use software library for encryption, decryption, signatures, password hashing and more.
 
 Custom:
+  PackagingRepo: https://github.com/sailfishos-chum/libsodium
   Repo: https://github.com/jedisct1/libsodium
 
 %prep


### PR DESCRIPTION
Not sure it is *necessary* but while fixing the build for 5.0 why not update.

Users of this in Chum AFAICS are python-zmq and libzmq, plus unbound.

- **Version bump: upstream 1.0.20-RELEASE**
- **Add Chum meta packaging repo**
- **Clean up .spec a bit**
